### PR TITLE
grpc-web での接続に変更

### DIFF
--- a/src/conmponents/query-provider/index.tsx
+++ b/src/conmponents/query-provider/index.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { TransportProvider } from '@connectrpc/connect-query';
-import { createConnectTransport } from '@connectrpc/connect-web';
+import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-const connectTransport = createConnectTransport({
+const connectTransport = createGrpcWebTransport({
   baseUrl: 'http://localhost:8080',
 });
 


### PR DESCRIPTION
buf.gen ではなく、 React コード内で使用する transport の生成関数を変えるだけで対応できた。

↓ リクエスト結果のレスポンスがバイナリになっている (修正前は JSON で返されていた)
![スクリーンショット 2025-06-15 21 02 54](https://github.com/user-attachments/assets/74cfb39c-7037-4045-b4ab-c157dacaa4e2)

↓ ただ、リクエスト自体は HTTP/1.1 になっている。
![スクリーンショット 2025-06-15 21 03 39](https://github.com/user-attachments/assets/cae0ca6d-3dbc-4c4d-84e5-6c32a57b4621)

このあたりはおそらく Connect がよしなにやってくれてるんだと思う...